### PR TITLE
Accelerate training by performing all loss ops on the device

### DIFF
--- a/data/utils.py
+++ b/data/utils.py
@@ -99,7 +99,7 @@ def multiclass_noisify(y, P, random_state=0):
     """ Flip classes according to transition probability matrix T.
     It expects a number between 0 and the number of classes - 1.
     """
-    print np.max(y), P.shape[0]
+    print(np.max(y), P.shape[0])
     assert P.shape[0] == P.shape[1]
     assert np.max(y) < P.shape[0]
 
@@ -108,7 +108,7 @@ def multiclass_noisify(y, P, random_state=0):
     assert (P >= 0.0).all()
 
     m = y.shape[0]
-    print m
+    print(m)
     new_y = y.copy()
     flipper = np.random.RandomState(random_state)
 
@@ -142,7 +142,7 @@ def noisify_pairflip(y_train, noise, random_state=None, nb_classes=10):
         assert actual_noise > 0.0
         print('Actual noise %.2f' % actual_noise)
         y_train = y_train_noisy
-    print P
+    print(P)
 
     return y_train, actual_noise
 
@@ -167,7 +167,7 @@ def noisify_multiclass_symmetric(y_train, noise, random_state=None, nb_classes=1
         assert actual_noise > 0.0
         print('Actual noise %.2f' % actual_noise)
         y_train = y_train_noisy
-    print P
+    print(P)
 
     return y_train, actual_noise
 

--- a/loss.py
+++ b/loss.py
@@ -2,23 +2,23 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
-import numpy as np
+
 
 # Loss functions
 def loss_coteaching(y_1, y_2, t, forget_rate, ind, noise_or_not):
     loss_1 = F.cross_entropy(y_1, t, reduce = False)
-    ind_1_sorted = np.argsort(loss_1.data).cuda()
+    ind_1_sorted = torch.argsort(loss_1.data)
     loss_1_sorted = loss_1[ind_1_sorted]
 
     loss_2 = F.cross_entropy(y_2, t, reduce = False)
-    ind_2_sorted = np.argsort(loss_2.data).cuda()
+    ind_2_sorted = torch.argsort(loss_2.data)
     loss_2_sorted = loss_2[ind_2_sorted]
 
     remember_rate = 1 - forget_rate
     num_remember = int(remember_rate * len(loss_1_sorted))
 
-    pure_ratio_1 = np.sum(noise_or_not[ind[ind_1_sorted[:num_remember]]])/float(num_remember)
-    pure_ratio_2 = np.sum(noise_or_not[ind[ind_2_sorted[:num_remember]]])/float(num_remember)
+    pure_ratio_1 = torch.sum(noise_or_not[ind[ind_1_sorted[:num_remember]]])/float(num_remember)
+    pure_ratio_2 = torch.sum(noise_or_not[ind[ind_2_sorted[:num_remember]]])/float(num_remember)
 
     ind_1_update=ind_1_sorted[:num_remember]
     ind_2_update=ind_2_sorted[:num_remember]
@@ -26,6 +26,6 @@ def loss_coteaching(y_1, y_2, t, forget_rate, ind, noise_or_not):
     loss_1_update = F.cross_entropy(y_1[ind_2_update], t[ind_2_update])
     loss_2_update = F.cross_entropy(y_2[ind_1_update], t[ind_1_update])
 
-    return torch.sum(loss_1_update)/num_remember, torch.sum(loss_2_update)/num_remember, pure_ratio_1, pure_ratio_2
+    return torch.sum(loss_1_update)/num_remember, torch.sum(loss_2_update)/num_remember, pure_ratio_1.item(), pure_ratio_2.item()
 
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 # -*- coding:utf-8 -*-
 import os
-import torch 
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
@@ -12,19 +12,22 @@ import argparse, sys
 import numpy as np
 import datetime
 import shutil
+from tqdm import tqdm
 
 from loss import loss_coteaching
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--lr', type = float, default = 0.001)
-parser.add_argument('--result_dir', type = str, help = 'dir to save result txt files', default = 'results/')
-parser.add_argument('--noise_rate', type = float, help = 'corruption rate, should be less than 1', default = 0.2)
-parser.add_argument('--forget_rate', type = float, help = 'forget rate', default = None)
-parser.add_argument('--noise_type', type = str, help='[pairflip, symmetric]', default='pairflip')
-parser.add_argument('--num_gradual', type = int, default = 10, help='how many epochs for linear drop rate, can be 5, 10, 15. This parameter is equal to Tk for R(T) in Co-teaching paper.')
-parser.add_argument('--exponent', type = float, default = 1, help='exponent of the forget rate, can be 0.5, 1, 2. This parameter is equal to c in Tc for R(T) in Co-teaching paper.')
+parser.add_argument('--lr', type=float, default=0.001)
+parser.add_argument('--result_dir', type=str, help='dir to save result txt files', default='results/')
+parser.add_argument('--noise_rate', type=float, help='corruption rate, should be less than 1', default=0.2)
+parser.add_argument('--forget_rate', type=float, help='forget rate', default=None)
+parser.add_argument('--noise_type', type=str, help='[pairflip, symmetric]', default='pairflip')
+parser.add_argument('--num_gradual', type=int, default=10,
+                    help='how many epochs for linear drop rate, can be 5, 10, 15. This parameter is equal to Tk for R(T) in Co-teaching paper.')
+parser.add_argument('--exponent', type=float, default=1,
+                    help='exponent of the forget rate, can be 0.5, 1, 2. This parameter is equal to c in Tc for R(T) in Co-teaching paper.')
 parser.add_argument('--top_bn', action='store_true')
-parser.add_argument('--dataset', type = str, help = 'mnist, cifar10, or cifar100', default = 'mnist')
+parser.add_argument('--dataset', type=str, help='mnist, cifar10, or cifar100', default='mnist')
 parser.add_argument('--n_epoch', type=int, default=200)
 parser.add_argument('--seed', type=int, default=1)
 parser.add_argument('--print_freq', type=int, default=50)
@@ -38,83 +41,89 @@ args = parser.parse_args()
 torch.manual_seed(args.seed)
 torch.cuda.manual_seed(args.seed)
 
+device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+# device = "cpu"
+print(device)
+
 # Hyper Parameters
 batch_size = 128
-learning_rate = args.lr 
+learning_rate = args.lr
 
 # load dataset
-if args.dataset=='mnist':
-    input_channel=1
-    num_classes=10
+if args.dataset == 'mnist':
+    input_channel = 1
+    num_classes = 10
     args.top_bn = False
     args.epoch_decay_start = 80
     args.n_epoch = 200
     train_dataset = MNIST(root='./data/',
-                                download=True,  
-                                train=True, 
-                                transform=transforms.ToTensor(),
-                                noise_type=args.noise_type,
-                                noise_rate=args.noise_rate
-                         )
-    
+                          download=True,
+                          train=True,
+                          transform=transforms.ToTensor(),
+                          noise_type=args.noise_type,
+                          noise_rate=args.noise_rate
+                          )
+
     test_dataset = MNIST(root='./data/',
-                               download=True,  
-                               train=False, 
-                               transform=transforms.ToTensor(),
-                               noise_type=args.noise_type,
-                               noise_rate=args.noise_rate
-                        )
-    
-if args.dataset=='cifar10':
-    input_channel=3
-    num_classes=10
+                         download=True,
+                         train=False,
+                         transform=transforms.ToTensor(),
+                         noise_type=args.noise_type,
+                         noise_rate=args.noise_rate
+                         )
+
+if args.dataset == 'cifar10':
+    input_channel = 3
+    num_classes = 10
     args.top_bn = False
     args.epoch_decay_start = 80
     args.n_epoch = 200
     train_dataset = CIFAR10(root='./data/',
-                                download=True,  
-                                train=True, 
-                                transform=transforms.ToTensor(),
-                                noise_type=args.noise_type,
-                                noise_rate=args.noise_rate
-                           )
-    
-    test_dataset = CIFAR10(root='./data/',
-                                download=True,  
-                                train=False, 
-                                transform=transforms.ToTensor(),
-                                noise_type=args.noise_type,
-                                noise_rate=args.noise_rate
-                          )
+                            download=True,
+                            train=True,
+                            transform=transforms.ToTensor(),
+                            noise_type=args.noise_type,
+                            noise_rate=args.noise_rate
+                            )
 
-if args.dataset=='cifar100':
-    input_channel=3
-    num_classes=100
+    test_dataset = CIFAR10(root='./data/',
+                           download=True,
+                           train=False,
+                           transform=transforms.ToTensor(),
+                           noise_type=args.noise_type,
+                           noise_rate=args.noise_rate
+                           )
+
+if args.dataset == 'cifar100':
+    input_channel = 3
+    num_classes = 100
     args.top_bn = False
     args.epoch_decay_start = 100
     args.n_epoch = 200
     train_dataset = CIFAR100(root='./data/',
-                                download=True,  
-                                train=True, 
-                                transform=transforms.ToTensor(),
-                                noise_type=args.noise_type,
-                                noise_rate=args.noise_rate
-                            )
-    
+                             download=True,
+                             train=True,
+                             transform=transforms.ToTensor(),
+                             noise_type=args.noise_type,
+                             noise_rate=args.noise_rate
+                             )
+
     test_dataset = CIFAR100(root='./data/',
-                                download=True,  
-                                train=False, 
-                                transform=transforms.ToTensor(),
-                                noise_type=args.noise_type,
-                                noise_rate=args.noise_rate
+                            download=True,
+                            train=False,
+                            transform=transforms.ToTensor(),
+                            noise_type=args.noise_type,
+                            noise_rate=args.noise_rate
                             )
 
 if args.forget_rate is None:
-    forget_rate=args.noise_rate
+    forget_rate = args.noise_rate
 else:
-    forget_rate=args.forget_rate
+    forget_rate = args.forget_rate
 
 noise_or_not = train_dataset.noise_or_not
+noise_or_not = noise_or_not.astype(float)
+noise_or_not = torch.tensor(noise_or_not, device=device, dtype=torch.float)
 
 # Adjust learning rate and betas for Adam Optimizer
 mom1 = 0.9
@@ -125,26 +134,28 @@ for i in range(args.epoch_decay_start, args.n_epoch):
     alpha_plan[i] = float(args.n_epoch - i) / (args.n_epoch - args.epoch_decay_start) * learning_rate
     beta1_plan[i] = mom2
 
+
 def adjust_learning_rate(optimizer, epoch):
     for param_group in optimizer.param_groups:
-        param_group['lr']=alpha_plan[epoch]
-        param_group['betas']=(beta1_plan[epoch], 0.999) # Only change beta1
-        
+        param_group['lr'] = alpha_plan[epoch]
+        param_group['betas'] = (beta1_plan[epoch], 0.999)  # Only change beta1
+
+
 # define drop rate schedule
-rate_schedule = np.ones(args.n_epoch)*forget_rate
-rate_schedule[:args.num_gradual] = np.linspace(0, forget_rate**args.exponent, args.num_gradual)
-   
-save_dir = args.result_dir +'/' +args.dataset+'/coteaching/'
+rate_schedule = np.ones(args.n_epoch) * forget_rate
+rate_schedule[:args.num_gradual] = np.linspace(0, forget_rate ** args.exponent, args.num_gradual)
+
+save_dir = args.result_dir + '/' + args.dataset + '/coteaching/'
 
 if not os.path.exists(save_dir):
     os.system('mkdir -p %s' % save_dir)
 
-model_str=args.dataset+'_coteaching_'+args.noise_type+'_'+str(args.noise_rate)
+model_str = args.dataset + '_coteaching_' + args.noise_type + '_' + str(args.noise_rate)
 
-txtfile=save_dir+"/"+model_str+".txt"
-nowTime=datetime.datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+txtfile = save_dir + "/" + model_str + ".txt"
+nowTime = datetime.datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
 if os.path.exists(txtfile):
-    os.system('mv %s %s' % (txtfile, txtfile+".bak-%s" % nowTime))
+    os.system('mv %s %s' % (txtfile, txtfile + ".bak-%s" % nowTime))
 
 
 def accuracy(logit, target, topk=(1,)):
@@ -163,39 +174,42 @@ def accuracy(logit, target, topk=(1,)):
         res.append(correct_k.mul_(100.0 / batch_size))
     return res
 
-# Train the Model
-def train(train_loader,epoch, model1, optimizer1, model2, optimizer2):
-    print 'Training %s...' % model_str
-    pure_ratio_list=[]
-    pure_ratio_1_list=[]
-    pure_ratio_2_list=[]
-    
-    train_total=0
-    train_correct=0 
-    train_total2=0
-    train_correct2=0 
 
-    for i, (images, labels, indexes) in enumerate(train_loader):
-        ind=indexes.cpu().numpy().transpose()
-        if i>args.num_iter_per_epoch:
+# Train the Model
+def train(train_loader, epoch, model1, optimizer1, model2, optimizer2):
+    print('Training %s...' % model_str)
+    pure_ratio_list = []
+    pure_ratio_1_list = []
+    pure_ratio_2_list = []
+
+    train_total = 0
+    train_correct = 0
+    train_total2 = 0
+    train_correct2 = 0
+
+    for i, (images, labels, indexes) in tqdm(enumerate(train_loader)):
+        # ind=indexes.cpu().numpy().transpose()
+        ind = indexes
+        if i > args.num_iter_per_epoch:
             break
-      
+
         images = Variable(images).cuda()
         labels = Variable(labels).cuda()
-        
+
         # Forward + Backward + Optimize
-        logits1=model1(images)
+        logits1 = model1(images)
         prec1, _ = accuracy(logits1, labels, topk=(1, 5))
-        train_total+=1
-        train_correct+=prec1
+        train_total += 1
+        train_correct += prec1
 
         logits2 = model2(images)
         prec2, _ = accuracy(logits2, labels, topk=(1, 5))
-        train_total2+=1
-        train_correct2+=prec2
-        loss_1, loss_2, pure_ratio_1, pure_ratio_2 = loss_coteaching(logits1, logits2, labels, rate_schedule[epoch], ind, noise_or_not)
-        pure_ratio_1_list.append(100*pure_ratio_1)
-        pure_ratio_2_list.append(100*pure_ratio_2)
+        train_total2 += 1
+        train_correct2 += prec2
+        loss_1, loss_2, pure_ratio_1, pure_ratio_2 = loss_coteaching(logits1, logits2, labels, rate_schedule[epoch],
+                                                                     ind, noise_or_not)
+        pure_ratio_1_list.append(100 * pure_ratio_1)
+        pure_ratio_2_list.append(100 * pure_ratio_2)
 
         optimizer1.zero_grad()
         loss_1.backward()
@@ -203,18 +217,22 @@ def train(train_loader,epoch, model1, optimizer1, model2, optimizer2):
         optimizer2.zero_grad()
         loss_2.backward()
         optimizer2.step()
-        if (i+1) % args.print_freq == 0:
-            print ('Epoch [%d/%d], Iter [%d/%d] Training Accuracy1: %.4F, Training Accuracy2: %.4f, Loss1: %.4f, Loss2: %.4f, Pure Ratio1: %.4f, Pure Ratio2 %.4f' 
-                  %(epoch+1, args.n_epoch, i+1, len(train_dataset)//batch_size, prec1, prec2, loss_1.data[0], loss_2.data[0], np.sum(pure_ratio_1_list)/len(pure_ratio_1_list), np.sum(pure_ratio_2_list)/len(pure_ratio_2_list)))
+        if (i + 1) % args.print_freq == 0:
+            print(
+                'Epoch [%d/%d], Iter [%d/%d] Training Accuracy1: %.4F, Training Accuracy2: %.4f, Loss1: %.4f, Loss2: %.4f, Pure Ratio1: %.4f, Pure Ratio2 %.4f'
+                % (epoch + 1, args.n_epoch, i + 1, len(train_dataset) // batch_size, prec1, prec2, loss_1.item(),
+                   loss_2.item(), np.sum(pure_ratio_1_list) / len(pure_ratio_1_list),
+                   np.sum(pure_ratio_2_list) / len(pure_ratio_2_list)))
 
-    train_acc1=float(train_correct)/float(train_total)
-    train_acc2=float(train_correct2)/float(train_total2)
+    train_acc1 = float(train_correct) / float(train_total)
+    train_acc2 = float(train_correct2) / float(train_total2)
     return train_acc1, train_acc2, pure_ratio_1_list, pure_ratio_2_list
+
 
 # Evaluate the Model
 def evaluate(test_loader, model1, model2):
-    print 'Evaluating %s...' % model_str
-    model1.eval()    # Change model to 'eval' mode.
+    print('Evaluating %s...' % model_str)
+    model1.eval()  # Change model to 'eval' mode.
     correct1 = 0
     total1 = 0
     for images, labels, _ in test_loader:
@@ -225,7 +243,7 @@ def evaluate(test_loader, model1, model2):
         total1 += labels.size(0)
         correct1 += (pred1.cpu() == labels).sum()
 
-    model2.eval()    # Change model to 'eval' mode 
+    model2.eval()  # Change model to 'eval' mode
     correct2 = 0
     total2 = 0
     for images, labels, _ in test_loader:
@@ -235,53 +253,57 @@ def evaluate(test_loader, model1, model2):
         _, pred2 = torch.max(outputs2.data, 1)
         total2 += labels.size(0)
         correct2 += (pred2.cpu() == labels).sum()
- 
-    acc1 = 100*float(correct1)/float(total1)
-    acc2 = 100*float(correct2)/float(total2)
+
+    acc1 = 100 * float(correct1) / float(total1)
+    acc2 = 100 * float(correct2) / float(total2)
     return acc1, acc2
 
 
 def main():
     # Data Loader (Input Pipeline)
-    print 'loading dataset...'
+    print('loading dataset...')
     train_loader = torch.utils.data.DataLoader(dataset=train_dataset,
-                                               batch_size=batch_size, 
+                                               batch_size=batch_size,
                                                num_workers=args.num_workers,
                                                drop_last=True,
                                                shuffle=True)
-    
+
     test_loader = torch.utils.data.DataLoader(dataset=test_dataset,
-                                              batch_size=batch_size, 
+                                              batch_size=batch_size,
                                               num_workers=args.num_workers,
                                               drop_last=True,
                                               shuffle=False)
     # Define models
-    print 'building model...'
+    print('building model...')
     cnn1 = CNN(input_channel=input_channel, n_outputs=num_classes)
     cnn1.cuda()
-    print cnn1.parameters
+    print(cnn1.parameters)
     optimizer1 = torch.optim.Adam(cnn1.parameters(), lr=learning_rate)
-    
+
     cnn2 = CNN(input_channel=input_channel, n_outputs=num_classes)
     cnn2.cuda()
-    print cnn2.parameters
+    print(cnn2.parameters)
     optimizer2 = torch.optim.Adam(cnn2.parameters(), lr=learning_rate)
 
-    mean_pure_ratio1=0
-    mean_pure_ratio2=0
+    mean_pure_ratio1 = 0
+    mean_pure_ratio2 = 0
 
     with open(txtfile, "a") as myfile:
         myfile.write('epoch: train_acc1 train_acc2 test_acc1 test_acc2 pure_ratio1 pure_ratio2\n')
 
-    epoch=0
-    train_acc1=0
-    train_acc2=0
+    epoch = 0
+    train_acc1 = 0
+    train_acc2 = 0
     # evaluate models with random weights
-    test_acc1, test_acc2=evaluate(test_loader, cnn1, cnn2)
-    print('Epoch [%d/%d] Test Accuracy on the %s test images: Model1 %.4f %% Model2 %.4f %% Pure Ratio1 %.4f %% Pure Ratio2 %.4f %%' % (epoch+1, args.n_epoch, len(test_dataset), test_acc1, test_acc2, mean_pure_ratio1, mean_pure_ratio2))
+    test_acc1, test_acc2 = evaluate(test_loader, cnn1, cnn2)
+    print(
+        'Epoch [%d/%d] Test Accuracy on the %s test images: Model1 %.4f %% Model2 %.4f %% Pure Ratio1 %.4f %% Pure Ratio2 %.4f %%' % (
+        epoch + 1, args.n_epoch, len(test_dataset), test_acc1, test_acc2, mean_pure_ratio1, mean_pure_ratio2))
     # save results
     with open(txtfile, "a") as myfile:
-        myfile.write(str(int(epoch)) + ': '  + str(train_acc1) +' '  + str(train_acc2) +' '  + str(test_acc1) + " " + str(test_acc2) + ' '  + str(mean_pure_ratio1) + ' '  + str(mean_pure_ratio2) + "\n")
+        myfile.write(
+            str(int(epoch)) + ': ' + str(train_acc1) + ' ' + str(train_acc2) + ' ' + str(test_acc1) + " " + str(
+                test_acc2) + ' ' + str(mean_pure_ratio1) + ' ' + str(mean_pure_ratio2) + "\n")
 
     # training
     for epoch in range(1, args.n_epoch):
@@ -290,15 +312,21 @@ def main():
         adjust_learning_rate(optimizer1, epoch)
         cnn2.train()
         adjust_learning_rate(optimizer2, epoch)
-        train_acc1, train_acc2, pure_ratio_1_list, pure_ratio_2_list=train(train_loader, epoch, cnn1, optimizer1, cnn2, optimizer2)
+        train_acc1, train_acc2, pure_ratio_1_list, pure_ratio_2_list = train(train_loader, epoch, cnn1, optimizer1,
+                                                                             cnn2, optimizer2)
         # evaluate models
-        test_acc1, test_acc2=evaluate(test_loader, cnn1, cnn2)
+        test_acc1, test_acc2 = evaluate(test_loader, cnn1, cnn2)
         # save results
-        mean_pure_ratio1 = sum(pure_ratio_1_list)/len(pure_ratio_1_list)
-        mean_pure_ratio2 = sum(pure_ratio_2_list)/len(pure_ratio_2_list)
-        print('Epoch [%d/%d] Test Accuracy on the %s test images: Model1 %.4f %% Model2 %.4f %%, Pure Ratio 1 %.4f %%, Pure Ratio 2 %.4f %%' % (epoch+1, args.n_epoch, len(test_dataset), test_acc1, test_acc2, mean_pure_ratio1, mean_pure_ratio2))
+        mean_pure_ratio1 = sum(pure_ratio_1_list) / len(pure_ratio_1_list)
+        mean_pure_ratio2 = sum(pure_ratio_2_list) / len(pure_ratio_2_list)
+        print(
+            'Epoch [%d/%d] Test Accuracy on the %s test images: Model1 %.4f %% Model2 %.4f %%, Pure Ratio 1 %.4f %%, Pure Ratio 2 %.4f %%' % (
+            epoch + 1, args.n_epoch, len(test_dataset), test_acc1, test_acc2, mean_pure_ratio1, mean_pure_ratio2))
         with open(txtfile, "a") as myfile:
-            myfile.write(str(int(epoch)) + ': '  + str(train_acc1) +' '  + str(train_acc2) +' '  + str(test_acc1) + " " + str(test_acc2) + ' ' + str(mean_pure_ratio1) + ' ' + str(mean_pure_ratio2) + "\n")
+            myfile.write(
+                str(int(epoch)) + ': ' + str(train_acc1) + ' ' + str(train_acc2) + ' ' + str(test_acc1) + " " + str(
+                    test_acc2) + ' ' + str(mean_pure_ratio1) + ' ' + str(mean_pure_ratio2) + "\n")
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
Hello,
I have noticed that some ops for the coteaching loss were performed on the host, using numpy, such as argsort or array slicing. I wanted to suggest these some small changes in order to have a device only pipeline.
I have also made small changes for the print calls, as I was running on python 3.
Thanks :)